### PR TITLE
Add Portuguese setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,3 +260,6 @@ API 可用于方便的使 GPTs 实现 Actions
 ## 致谢
 * [EmbraceAGI](https://github.com/EmbraceAGI) 感谢 EmbraceAGI 社区对本项目的支持!
 
+
+## Guia em Português
+Consulte [docs/claude_mcp_setup_pt.md](docs/claude_mcp_setup_pt.md) para um guia de setup inicial do agente Claude integrado ao MCP.

--- a/docs/claude_mcp_setup_pt.md
+++ b/docs/claude_mcp_setup_pt.md
@@ -1,0 +1,60 @@
+# Guia de Setup Inicial e Boas Práticas
+
+Este guia descreve um modelo de arquitetura e governança para um agente baseado no Claude integrado ao MCP (Middleware de Contexto e Persistência). O objetivo é manter eficiência e organização em um MacBook Pro M4 com 24 GB de RAM, SSD interno de 1 TB e armazenamento complementar em SSD externa de 2 TB e unidade USB de 128 GB para boot.
+
+## 1. Visão Geral
+
+- **Sistema:** macOS no SSD interno (1 TB).
+- **Armazenamento de dados:** SSD externa Kingston 2 TB (leitura 1000 MB/s, escrita 150 MB/s).
+- **Disco de boot/instalação:** USB Kingston 128 GB.
+- **Pasta de trabalho principal:** `/Users/luiz.sena88`.
+
+A combinação de armazenamento interno e externo oferece espaço e velocidade para executar o agente e manter bases de dados locais.
+
+## 2. Setup Inicial
+
+1. **Instalação do macOS** no SSD interno.
+2. **Configuração do USB boot** para reinstalação ou recuperação.
+3. **Particionamento da SSD externa**: criar uma partição dedicada a projetos de IA (ex.: `AIProjects`) e outra para backups.
+4. **Montagem automática**: configure o macOS para montar a SSD externa no login, garantindo que o agente tenha acesso aos dados.
+
+## 3. Organização de Pastas
+
+Estruture a pasta principal seguindo o princípio de clareza e reutilização:
+
+```text
+Users/luiz.sena88/
+├── AIProjects/
+│   ├── datasets/        # Bases de dados para RAG
+│   ├── models/          # Modelos localmente armazenados
+│   ├── scripts/         # Automatizações e utilidades
+│   └── logs/            # Registros de execução
+├── backups/             # Cópias de segurança
+└── tmp/                 # Arquivos temporários
+```
+
+Use nomes consistentes para variáveis de ambiente, como `MCP_DATA_PATH`, `MCP_LOG_PATH` e `MCP_MODELS_PATH`, mantendo todos os caminhos centralizados em arquivos `.env`.
+
+## 4. Arquitetura do Agente Claude + MCP
+
+1. **Camada de Entrada**
+   - Colete prompts e consultas via interface de linha ou aplicativo específico.
+2. **RAG (Retrieval-Augmented Generation)**
+   - Utilize bases de dados em `datasets/` com indexação otimizada.
+   - Integre ao MCP para gerenciar a memória curta e longa do agente.
+3. **Processamento**
+   - Defina papéis (roles) como "pesquisador", "analista" e "escritor" para modular o fluxo de prompts.
+   - Padronize variáveis e comandos usando checklists.
+4. **Geração de Resposta**
+   - O agente Claude produz a resposta final utilizando contexto recuperado e regras de negócio definidas.
+
+## 5. Boas Práticas de Governança
+
+- **Mapeamento e padronização** de processos: documente cada etapa em fluxogramas simples.
+- **Princípio de Pareto (80/20)**: identifique as variáveis mais críticas do MCP e monitore-as de forma prioritária.
+- **Checklists e folhas de verificação** para garantir consistência na configuração.
+- **Centralização de variáveis** em arquivos `.env` e automação via scripts (ex.: Ansible ou Docker Compose) para reproduzir o ambiente.
+- **Transformações de variáveis** (quando aplicável) a fim de normalizar dados para análise.
+- **FMEA**: avalie possíveis falhas de configuração que impactem o agente e crie planos de mitigação.
+
+Seguindo essas práticas, o ambiente mantém alta organização e facilita a manutenção ao longo do tempo.


### PR DESCRIPTION
## Summary
- documentar arquitetura e organização do agente Claude integrado ao MCP
- adicionar link para o guia em português no README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a16c295c0832f9eaeaef7f2b4b8ac